### PR TITLE
Fixed typos, language, and clarified interior/exterior rule

### DIFF
--- a/middle.mkd
+++ b/middle.mkd
@@ -88,11 +88,11 @@ at this place or in this form).
 
 * A hole is considered, for the sake of illustration, as simply a
   geometric shape that is to be excluded from the geometric shape
-  it appears in.
+  in which it appears.
 
-* When using the term interior geometric shape it is assumed, that
-  there exists an exterior shape so that the former is fully included
-  inside the convex hull of the latter.
+* When using the term interior geometric shape it is assumed that
+  there exists an exterior shape such that the former is fully included
+  inside the geometry of the latter.
 
 Note-sdrees: The last four items in the list above are added, to not
 forget to satisfy the need of defining these terms (but not necessarily
@@ -115,7 +115,7 @@ general and amend its usage with:
 
 Motivation for above proposal: The benefit would be, that we a) remain
 backwards compatible, but b) avoid future clashes with JSON of unclear
-provenience when being consumed by the client. Alternatively one might
+provenance when consuming in a client. Alternatively one might
 prefix all wonderful type names with say "geo" and a dot or so (not
 preferred) or even the names of the members (shiver).
 Ammendment-20130511-sdrees: I would not call it profile as I am used to
@@ -183,7 +183,7 @@ illustrate the data structures, but is not required.
 
 # GeoJSON Object
 
-As stated in the introduction, a complete Geospatial JSON (GeoJSON)
+As stated in the introduction, a complete GeoJSON
 data structure is always represented as a single JSON object that
 represents a geometry, feature, or collection of features and will be
 referred to as the GeoJSON object in this document.


### PR DESCRIPTION
Interior rings must fall within the geometry of the exterior ring, not just the convex hull of the exterior ring.
