### PR TITLE
Removing crsURN

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+20130516 - removed crsURN
 20130402 - reduced crsRef to single label with domain RFC 5165 like URN, thus renamed it to crsURN
 20130430 - moved repo to GeoJSONWG organization at https://github.com/GeoJSONWG/draft-geojson
 20130428 - typos corrected, editorial changes throughout the document and several notes partly explaining thes or requesting further changes or additions. Correction of inconsistent may in GeoJSON Object first list item into MUST, merge with second listitem and provision of js and bib folders

--- a/middle.mkd
+++ b/middle.mkd
@@ -190,10 +190,6 @@ referred to as the GeoJSON object in this document.
   value - additional rules apply, then these are stated in the
   following sections where each type is further defined.
 
-* A GeoJSON object MAY have an optional "crsURN" member. If it is present,
-  the value of it MUST be a valid coordinate reference system reference
-  (see "[3. Coordinate Reference System (CRS) Reference](rfc.section.3)").
-
 * A GeoJSON object MAY have a "bbox" member. If it is present,
   the value of it MUST be a bounding box array (see
   "4. Bounding Box").
@@ -222,17 +218,13 @@ member of a geometry object is composed of either:
 * or a multidimensional array of positions (MultiPolygon).
 
 A position is represented by an array of numbers. There MUST be two or
-more elements. In general the first two elements will be World Geodetic
-System (WGS 84) longitude and latitude, precisely in that order, and
-a third (optionally) will be altitude in meters.
+more elements. The first two elements will be World Geodetic System 1984
+(WGS 84) longitude and latitude, precisely in that order, and
+a third (optional element) will be altitude in meters.
 
 Any number of additional elements are allowed -- interpretation and
 meaning of additional elements is beyond the scope of this
 specification.
-
-GeoJSON data producers MAY indicate a different sense of the position
-elements by including a "crsURN" object in the position's context. See
-the Coordinate Reference System section below for details. 
 
 Examples of positions and geometries are provided in "Appendix A.
 Geometry Examples".
@@ -316,42 +308,10 @@ element in the array is a feature object as defined above.
 
 # Coordinate Reference System (CRS)
 
-The coordinate reference system of a GeoJSON object and the sense of
-coordinate order is determined by the value of its "crsURN" member
-(referred to as the CRS reference below). If an object has no crsURN
-member, then its parent or grandparent object's crsURN member may be
-acquired. If no crsURN member can be so acquired, the default CRS shall
-apply to the GeoJSON object.
-
-* The default CRS is a geographic coordinate reference system, using
-  the WGS84 datum, and with longitude and latitude units of decimal
-  degrees. In an array of coordinate values, longitude is first and is
-  followed by latitude. 
-
-* The value of a member named "crsURN" must be a string (referred to
-  as the CRS reference below) or JSON null. If the value of "crsURN" is
-  null, no CRS can be assumed. Note-sdrees: FIXME or default CRS as
-  when crsURN member is left out? It is optional anyway.
-
-* The crsURN member SHOULD be on the top-level GeoJSON object in the
-  following canonical hierarchical ordering, i.e. if present on a
-  feature collection, else if present on a feature, else on a geometry
-  and MUST NOT be repeated or overridden on children or
-  grandchildren of the object.
-
-Note-sdrees: The name has been changed from crs to crsURN to not
-irritate consumers that expect the crs object as of version 1.0 in the
-community spec.
-
-If present the CRS reference MUST indicate a coordinate reference
-system by name. In this case, the value of it MUST be a string
-identifying a coordinate reference system. OGC CRS URNs such as
-"urn:ogc:def:crs:OGC:1.3:CRS84" SHALL be preferred over legacy
-identifiers such as "EPSG:4326":
-
-    "crsURN": "urn:ogc:def:crs:OGC:1.3:CRS84"
-
-For the format of a valid URN cf. [RFC5165].
+The coordinate reference system of all GeoJSON objects is a geographic
+coordinate reference system, using the WGS84 datum, and with longitude and
+latitude units of decimal degrees. In an array of coordinate values,
+longitude is first and is followed by latitude.
 
 # Bounding Box
 
@@ -361,9 +321,6 @@ collections. The value of the bbox member MUST be an array of length
 2*n where n is the number of dimensions represented in the contained
 geometries, with the lowest values for all axes followed by the highest
 values. The axes order of a bbox follows the axes order of geometries.
-In addition, the coordinate reference system for the bbox is assumed to
-match the coordinate reference system of the GeoJSON object of which it
-is a member.
 
 Example of a bbox member on a feature:
 


### PR DESCRIPTION
**update (2014-01-08): The original CRS sections have been returned to the draft, but a strong recommendation for use of the default CRS84. Software, like Leaftlet, that has core support only for CRS84 is completely in line with the draft.**

This makes all GeoJSON positions latitude, longitude [, elevation in meters] relative to an ellispoidal CRS based on the WGS84 datum.

I'm in favor of restricting the allowed coordinate reference systems for GeoJSON objects to 1: CRS84.

I think the second best alternative would be to restrict to 2: CRS84 or EPGS:3857. But that means we'll only be cool as long as Google Mercator is cool. And 2 is pretty arbitrary. Soon people will want 3.

I don't like the "allow any CRS and let axis order follow the CRS" because I think it either reduces interoperability or imposes an unreasonable burden on web clients (I don't know of a good web service - or really want to depend on one - that provides axis order information for arbitrary CRS URN, and the table is too big to ask every client to carry around).

With all GeoJSON coming in a known CRS, clients that want to consume any GeoJSON but work or render in a different CRS shouldn't have a hard time finding code to do coordinate transforms. This is a smaller burden than being able to look up axis order for any CRS URN.

(Note that this is a second pass at #2.)
