### PR TITLE
Remove validity constraint from polygons

### DIFF
--- a/middle.mkd
+++ b/middle.mkd
@@ -91,8 +91,7 @@ at this place or in this form).
   in which it appears.
 
 * When using the term interior geometric shape it is assumed that
-  there exists an exterior shape such that the former is fully included
-  inside the geometry of the latter.
+  there exists an exterior shape.
 
 Note-sdrees: The last four items in the list above are added, to not
 forget to satisfy the need of defining these terms (but not necessarily


### PR DESCRIPTION
As [discussed](https://github.com/GeoJSONWG/draft-geojson/pull/3#issuecomment-17956266) in #3, we don't want to enforce that GeoJSON geometries be valid.

This branch also cherry-picks the typo fixes that came with 424a06e43b7c5f3beb03d52684d97540f8389c65 (which was reverted in the batch with b4d6c641a84eb50d49cd50f1983bf06dd6659181).
