### PR TITLE
how to use default crs

### DIFF
--- a/middle.mkd
+++ b/middle.mkd
@@ -277,7 +277,7 @@ following specifications shall be followed:
 
 * The value of a member named "crs" is a JSON object (referred to as the
   CRS object below) or JSON null. If the value of CRS is null, no CRS can be
-  assumed. GeoJSON data utilizing the default CRS should have no CRS member.
+  assumed. GeoJSON data utilizing the default CRS SHOULD have no CRS member.
 
 
 * A non-null CRS object has two mandatory members: "type" and "properties".


### PR DESCRIPTION
One more larger change.  This might need a bit more discussion, or you may want to take a different approach.  (So feel free to close / not merge for now.)

Basically the goal is to be more explicit about how to "specify" the default CRS, and in particular draw out the distinction between `crs: null` and no crs.
