### PR TITLE
Specify that Feature.id SHALL be a string.

### DIFF
--- a/middle.mkd
+++ b/middle.mkd
@@ -242,9 +242,9 @@ A GeoJSON object with the type "Feature" is a feature object.
   value of the properties member is an object (any JSON object or a
   JSON null value).
 
-* If a feature has a commonly used identifier, that identifier SHOULD
-  be included as a member of the feature object with the name "id".
-  These identifiers SHALL be strings.
+* If a feature has a commonly used identifier, that identifier SHOULD be
+  included as a member of the feature object with the name "id" and the
+  value of this member is either a JSON string or number.
 
 ## Feature Collection Object
 


### PR DESCRIPTION
As I said in https://github.com/mapbox/geojsonhint/issues/16, I think that string is absolutely the best type for Feature ids and that the I-D should say so and require it.
