### PR TITLE
Add "gml" to list of suggested CRS representations

### DIFF
--- a/middle.mkd
+++ b/middle.mkd
@@ -318,7 +318,7 @@ A link object has one required member: "href", and one optional member: "type".
 The value of the required "href" member must be a dereferenceable URI. The
 value of the optional "type" member must be a string that hints at the
 format used to represent CRS parameters at the provided URI. Suggested values
-are: "proj4", "ogcwkt", "esriwkt", but others can be used::
+are: "proj4", "ogcwkt", "esriwkt", "gml", but others can be used::
 
     "crs": {
         "type": "link", 
@@ -327,7 +327,7 @@ are: "proj4", "ogcwkt", "esriwkt", but others can be used::
             "type": "proj4"
         }
     }
-    
+
 Relative links may be used to direct processors to CRS parameters in an
 auxiliary file:
 


### PR DESCRIPTION
Per issue #28 - given availability of CRS services from EPSG and OGC which deliver results in GML, "gml" could be added to the list of suggested representations.
