### PR TITLE
CRS objects are seriously not recommended.

### DIFF
--- a/middle.mkd
+++ b/middle.mkd
@@ -29,7 +29,7 @@
    there is no particular service model or feature type ontology implied
    in the GeoJSON format specification.
 
-   Since its initial publication in 2008 [GeoJSON], the GeoJSON
+   Since its initial publication in 2008 [GJ2008], the GeoJSON
    format specification has steadily grown in popularity.  It is widely
    used in JavaScript web mapping libraries, JSON-based document
    databases, and web APIs.
@@ -59,7 +59,7 @@ is not significant in JSON.
 ## Specification of GeoJSON
 
 This document updates the original GeoJSON format specification
-[GeoJSON].
+[GJ2008].
 
 ## Definitions
 
@@ -273,7 +273,7 @@ reference ellipsoid. For widest interoperability, GeoJSON data SHOULD
 use this default coordinate reference system.
 
 Other coordinate reference systems, including ones described by CRS
-objects of the kind defined in [GeoJSON] are NOT RECOMMENDED. GeoJSON
+objects of the kind defined in [GJ2008] are NOT RECOMMENDED. GeoJSON
 processing software SHALL NOT be expected to have access to coordinate
 reference systems databases.  Applications requiring CRS other than the
 default MUST assume all responsibility for reference system and

--- a/template.xml
+++ b/template.xml
@@ -115,7 +115,7 @@
        comes first in GeoJSON coordinates as it does in [KMLv2.2].
        </t>
        <t>
-       The original GeoJSON format specification [GeoJSON] included
+       The original GeoJSON format specification [GJ2008] included
        descriptions of coordinate reference system (CRS) objects. These are NOT
        RECOMMENDED but may be found in existing documents. When such a CRS is
        encountered in GeoJSON, the document should be processed with caution.
@@ -179,7 +179,9 @@
     <references title="Normative References">
         &pandocRef2119;
         &pandocRef7159;
-        <reference anchor="GeoJSON">
+    </references>
+    <references title="Informative References">
+        <reference anchor="GJ2008">
            <front>
                <title>The GeoJSON Format Specification</title>
                <author initials="H." surname="Butler" fullname="Howard Butler"></author>
@@ -191,8 +193,6 @@
                <date month="June" year="2008" />
            </front>
         </reference>
-    </references>
-    <references title="Informative References">
        <reference anchor="SFSQL">
            <front>
                <title>OpenGIS Simple Features Specification For SQL Revision 1.1</title>


### PR DESCRIPTION
Following up on discussion in #39.

I've removed them from the spec and only refer to them via refs to the original geosjon.org format spec. How can we say "not recommended" and yet show developers an ugly, terrible, complicated way to do it? (https://github.com/geojson/geojson-ld/issues/27 points to the right way)

Under interoperability considerations (expanded), I push all responsibility for use of non-default CRS onto servers and reiterate that servers must not under any circumstances give out lat,lng data. Serving lat,lng creates a world of hurt for developers (I hope we all agree).

To reiterate: this pull request makes CRS an application specific concern and points out that the CRS object from the original GeoJSON spec is one way (probably the most common way) to do it.

cc @geojson/owners @rajrsingh @dr-shorthair @jyutzler and also @elemoine (does this suit your needs, Éric?) 
