### PR TITLE
Formalize language in charter

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -9,11 +9,11 @@ web APIs, and open data platforms. However, shortcomings of its original
 specification have hindered and continue to hinder implementers. This working
 group is charged with the following tasks:
 
-- improving the clarity of the GeoJSON format specification.
-- removing features that have not been widely implemented or have hampered
-  interoperability.
-- adding implementation advice to the specification.
-- adding extension advice to the specification.
+- The improvement in the clarity of the GeoJSON format specification.
+- The deprecation and further removal of features that have not been widely
+  implemented or have hampered interoperability.
+- The addition of implementation advice to the specification.
+- The addition of extension advice to the specification.
 
 The addition of new features to the GeoJSON format specification is not within
 the charter of this working group.


### PR DESCRIPTION
This is an addition to #49 that adds more formal language to the list of charged tasks.

I have half a mind to remove the `not been widely implemented` as well. If it's not implemented, this means it's up to the implementations to get it so.  Only Firefox supports [SVG favicons](http://caniuse.com/#feat=link-icon-svg) so far, if this charter was for W3C would you remove it from the spec, or expect the other browsers to work towards complying to the spec.

Hope you like the changes!

If merged this would close #49 expectedly
