### PR TITLE
Interoperability, I-JSON, and must-ignore

### DIFF
--- a/bib/reference.RFC.7159.xml
+++ b/bib/reference.RFC.7159.xml
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<reference anchor="RFC7159">
+<?xml version='1.0' encoding='UTF-8'?>
 
+<reference  anchor='RFC7159' target='http://www.rfc-editor.org/info/rfc7159'>
 <front>
 <title>The JavaScript Object Notation (JSON) Data Interchange Format</title>
-<author initials="T." surname="Bray" fullname="T. Bray">
-<organization/></author>
-<date year="2014" month="March"/>
-<abstract>
-<t>JavaScript Object Notation (JSON) is a lightweight, text-based, language-independent data interchange format. It was derived from the ECMAScript Programming Language Standard. JSON defines a small set of formatting rules for the portable representation of structured data.&lt;/t&gt;&lt;t&gt; This document removes inconsistencies with other specifications of JSON, repairs specification errors, and offers experience-based interoperability guidance.</t></abstract></front>
-
-<seriesInfo name="RFC" value="7159"/>
-<format type="TXT" octets="27451" target="http://www.rfc-editor.org/rfc/rfc7159.txt"/>
+<author initials='T.' surname='Bray' fullname='T. Bray' role='editor'><organization /></author>
+<date year='2014' month='March' />
+<abstract><t>JavaScript Object Notation (JSON) is a lightweight, text-based, language-independent data interchange format.  It was derived from the ECMAScript Programming Language Standard.  JSON defines a small set of formatting rules for the portable representation of structured data.</t><t>This document removes inconsistencies with other specifications of JSON, repairs specification errors, and offers experience-based interoperability guidance.</t></abstract>
+</front>
+<seriesInfo name='RFC' value='7159'/>
+<seriesInfo name='DOI' value='10.17487/RFC7159'/>
 </reference>

--- a/considerations.mkd
+++ b/considerations.mkd
@@ -13,6 +13,24 @@
 
 # Interoperability Considerations
 
+## I-JSON
+
+GeoJSON texts SHOULD follow the constraints of I-JSON [RFC7493] for
+maximum interoperability.
+
+## Coordinate Precision
+
+The size of a GeoJSON text in bytes is a major interoperability
+consideration and precision of coordinate values has a large impact on
+the size of texts.  A GeoJSON text containing many detailed polygons can
+be inflated almost by a factor of two by increasing coordinate precision
+from 6 to 15 decimal places. 6 decimal places (a default common in,
+e.g., sprintf) amounts to about 10 centimeters, a precision well within
+that of modern GPS systems. Implementations should consider the cost to
+using a greater precision than necessary.
+
+## Coordinate Order
+
    There are conflicting precedents among geographic data formats over
    whether latitude or longitude come first in a pair of numbers.
    Longitude comes first in GeoJSON coordinates as it does in [KMLv2.2].
@@ -28,6 +46,8 @@
    necessary to interpret the coordinates properly; they may not be in
    the required longitude, latitude order.
 
+## Coordinate Reference System Identifiers
+
    Earlier versions of the GeoJSON specification recommended use of OGC
    URNs such as "urn:ogc:def:crs:OGC:1.3:CRS84" to name a CRS. This
    version deprecates the URNs and recommends a change to HTTP URLs
@@ -35,6 +55,8 @@
    libraries, currently write the deprecated OGC URNs into GeoJSON
    documents and will do so until replaced by newer versions. GeoJSON
    processors should be prepared for either form.
+
+## Bounding boxes
 
    In representing features that cross the dateline or the poles, 
    following the ring-orientation best practice (counter-clockwise 

--- a/considerations.mkd
+++ b/considerations.mkd
@@ -24,11 +24,11 @@ The size of a GeoJSON text in bytes is a major interoperability
 consideration and precision of coordinate values has a large impact on
 the size of texts.  A GeoJSON text containing many detailed polygons can
 be inflated almost by a factor of two by increasing coordinate precision
-from 6 to 15 decimal places. For geographic coordinates, 6 decimal
-places (a default common in, e.g., sprintf) amounts to about 10
-centimeters, a precision well within that of current GPS systems.
-Implementations should consider the cost to using a greater precision
-than necessary.
+from 6 to 15 decimal places. For geographic coordinates with units of
+degrees, 6 decimal places (a default common in, e.g., sprintf) amounts
+to about 10 centimeters, a precision well within that of current GPS
+systems.  Implementations should consider the cost to using a greater
+precision than necessary.
 
 ## Coordinate Order
 

--- a/considerations.mkd
+++ b/considerations.mkd
@@ -24,10 +24,11 @@ The size of a GeoJSON text in bytes is a major interoperability
 consideration and precision of coordinate values has a large impact on
 the size of texts.  A GeoJSON text containing many detailed polygons can
 be inflated almost by a factor of two by increasing coordinate precision
-from 6 to 15 decimal places. 6 decimal places (a default common in,
-e.g., sprintf) amounts to about 10 centimeters, a precision well within
-that of modern GPS systems. Implementations should consider the cost to
-using a greater precision than necessary.
+from 6 to 15 decimal places. For geographic coordinates, 6 decimal
+places (a default common in, e.g., sprintf) amounts to about 10
+centimeters, a precision well within that of current GPS systems.
+Implementations should consider the cost to using a greater precision
+than necessary.
 
 ## Coordinate Order
 

--- a/middle.mkd
+++ b/middle.mkd
@@ -135,13 +135,16 @@ GeoJSON always consists of a single object. This object (referred to as
 the GeoJSON object below) represents a geometry, feature, or collection
 of features.
 
+* The top level of GeoJSON text MUST be a JSON object.
+
 * The GeoJSON object MUST have a member with the name "type". The value
   of the member MUST be one of the GeoJSON types.
 
-* The GeoJSON object MAY have any number of other members.
-
 * A GeoJSON object MAY have a "bbox" member, the value of which MUST be
   a bounding box array (see 4. Bounding Boxes).
+
+* The GeoJSON object MAY have any number of other members.
+  Implementations MUST ignore unrecognized members.
 
 ## Geometry Object
 

--- a/template.xml
+++ b/template.xml
@@ -11,9 +11,10 @@
 <!ENTITY pandocRef7159  PUBLIC '' 'bib/reference.RFC.7159.xml'>
 <!ENTITY pandocRef5165  PUBLIC '' 'bib/reference.RFC.5165.xml'>
 <!ENTITY pandocRef5246  PUBLIC '' 'bib/reference.RFC.5246.xml'>
+<!ENTITY pandocRef7493  PUBLIC '' 'bib/reference.RFC.7493.xml'>
 ]>
 
-<rfc ipr="trust200902" category="info" docName="draft-butler-geojson-05">
+<rfc ipr="trust200902" category="info" docName="draft-butler-geojson-06">
 <?rfc toc="yes"?>         <!-- generate a table of contents -->
 <?rfc symrefs="yes"?>     <!-- use anchors instead of numbers for references -->
 <?rfc sortrefs="yes" ?>   <!-- alphabetize the references -->
@@ -67,7 +68,7 @@
                 <uri>http://stefan-hagen.website/</uri>
             </address>
         </author>
-        <date day="28" month="January" year="2015"/>
+        <date day="18" month="July" year="2015"/>
 
         <area>General</area>
         <workgroup>Independent</workgroup>
@@ -127,6 +128,7 @@
     <references title="Normative References">
         &pandocRef2119;
         &pandocRef7159;
+        &pandocRef7493;
     </references>
     <references title="Informative References">
         <reference anchor="GJ2008">


### PR DESCRIPTION
Add clearer language about top-level object and a must-ignore directive to section 2.

Organize interoperability considerations.

Add a section about coordinate precision to that section.

Add a section that recommends following the I-JSON constraints for maximum interoperability.

Closes #72.
Closes #82.
Closes #83.