### PR TITLE
GeoJSON-'geo' URI mappings

### DIFF
--- a/middle.mkd
+++ b/middle.mkd
@@ -384,7 +384,7 @@ are placeholders for 'geo' URI latitude, longitude, altitude, and uncertainty
 values, respectively.
 
 A 'geo' URI with two coordinates and an uncertainty ('u') parameter that
-is absent or zero and a GeoJSON Point geometry may be mapped to each other.
+is absent or zero, and a GeoJSON Point geometry may be mapped to each other.
 A GeoJSON point is always converted to a 'geo' URI that has no uncertainty
 parameter.
 
@@ -407,5 +407,5 @@ GeoJSON:
 
   {"type": "Point", "coordinates": [%lon%, %lat%, %alt%]}
 
-GeoJSON has no concept of uncertainty; imprecise or uncertain 'geo' URIs can
-not be mapped to GeoJSON geometries.
+GeoJSON has no concept of uncertainty; imprecise or uncertain 'geo' URIs thus
+can not be mapped to GeoJSON geometries.

--- a/middle.mkd
+++ b/middle.mkd
@@ -373,3 +373,39 @@ MultiLineString, MultiPolygon, and GeometryCollection.
 
 Implementations MUST NOT change the the semantics of GeoJSON properties
 and types.
+
+# Mapping 'geo' URIs
+
+'geo' URIs [RFC5870] identify geographic locations and precise (not uncertain)
+locations can be mapped to GeoJSON geometry objects.
+
+For this section, as in [RFC5870], "%lat%", "%lon%", "%alt%", and "%unc%"
+are placeholders for 'geo' URI latitude, longitude, altitude, and uncertainty
+values, respectively.
+
+A 'geo' URI with two coordinates and an uncertainty ('u') parameter that
+is absent or zero and a GeoJSON Point geometry may be mapped to each other.
+A GeoJSON point is always converted to a 'geo' URI that has no uncertainty
+parameter.
+
+'geo' URI:
+
+  geo:%lat%,%lon%
+
+GeoJSON:
+
+  {"type": "Point", "coordinates": [%lon%, %lat%]}
+
+The mapping between 'geo' URIs and GeoJSON points that specifiy elevation is
+shown below.
+
+'geo' URI:
+
+  geo:%lat%,%lon%,%alt%
+
+GeoJSON:
+
+  {"type": "Point", "coordinates": [%lon%, %lat%, %alt%]}
+
+GeoJSON has no concept of uncertainty; imprecise or uncertain 'geo' URIs can
+not be mapped to GeoJSON geometries.


### PR DESCRIPTION
Inspired by RFC5870's section 7.

Major difference between this and the GML mappings is that GeoJSON can't support mappings from uncertain locations. I'm not sure that GML really does, either. The uncertain 'geo' URI <-> circle/sphere mapping is a bit of a stretch, IMO. 

Closes #92