### PR TITLE
LinearRing first and last values MUST be the same

### DIFF
--- a/middle.mkd
+++ b/middle.mkd
@@ -213,8 +213,8 @@ the concept of a linear ring:
 
 * A linear ring is a closed LineString with 4 or more positions.
 
-* The first and last positions are equivalent (they represent
-  equivalent points).
+* The first and last positions are equivalent, they MUST contain identical
+  values; their representation SHOULD also be identical.
 
 * A linear ring is the boundary of a surface or the boundary of a hole in
   a surface.


### PR DESCRIPTION
The original text says that the two points are equivalent.  That sounds like an axiomatic statement, but we know it not to be always true since it is easy to mess up.

This changes the text to *require* that the values be the same and to *recommend* that their representation be the same.