### PR TITLE
Add antimeridian cutting recommendation

### DIFF
--- a/considerations.mkd
+++ b/considerations.mkd
@@ -56,16 +56,17 @@ longitude, latitude order.
 
 In representing features that cross the antimeridian, interoperability
 is improved by cutting geometries so that no single part crosses the
-antimeridian. For example, a line extending from 45dN, 170dE across the
-antimeridian to 45dN, 170dW should be cut in two and represented as a
-MultiLineString.
+antimeridian. For example, a line extending from 45 degrees N, 170
+degrees E across the antimeridian to 45 degrees N, 170 degrees W should
+be cut in two and represented as a MultiLineString.
 
     {"type": "MultiLineString", "coordinates": [
       [[170.0, 45.0], [180.0, 45.0]],
       [[-180.0, 45.0], [-170.0, 45.0]]]}
 
-A rectangle extending from 40dN, 170dE across the antimeridian to 50dN,
-170dW should be cut in two and represented as a MultiPolygon.
+A rectangle extending from 40 degrees N, 170 degrees E across the
+antimeridian to 50 degrees N, 170 degrees W should be cut in two and
+represented as a MultiPolygon.
 
     {"type": "MultiPolygon", "coordinates": [
       [[[180.0, 40.0], [180.0, 50.0], [170.0, 50.0], [170.0, 40.0],

--- a/considerations.mkd
+++ b/considerations.mkd
@@ -52,17 +52,26 @@ document should be processed with caution.  Heuristics may be necessary
 to interpret the coordinates properly; they may not be in the required
 longitude, latitude order.
 
-## Bounding boxes
+## Antimeridian cutting
 
-In representing features that cross the antimeridian or the poles,
-following the ring-orientation best practice (counter-clockwise external
-rings, clockwise internal rings) and ensuring your bounding boxes use
-the south-west corner as the first coordinate will improve
-interoperability.  Remain aware that software that represents edges as
-straight cartesian lines and software that represents edges as great
-circles will have different interpretations of edges, which vary more
-the longer the edges are. Try to avoid edges of more than 180 degrees in
-length as far as possible.
+In representing features that cross the antimeridian, interoperability
+is improved by cutting geometries so that no single part crosses the
+antimeridian. For example, a line extending from 45dN, 170dE across the
+antimeridian to 45dN, 170dW should be cut in two and represented as a
+MultiLineString.
+
+    {"type": "MultiLineString", "coordinates": [
+      [[170.0, 45.0], [180.0, 45.0]],
+      [[-180.0, 45.0], [-170.0, 45.0]]]}
+
+A rectangle extending from 40dN, 170dE across the antimeridian to 50dN,
+170dW should be cut in two and represented as a MultiPolygon.
+
+    {"type": "MultiPolygon", "coordinates": [
+      [[[180.0, 40.0], [180.0, 50.0], [170.0, 50.0], [170.0, 40.0],
+        [180.0, 40.0]]],
+      [[[-170.0, 40.0], [-170.0, 50.0], [-180.0, 50.0], [-180.0, 40.0],
+        [-170.0, 40.0]]]]}
 
 ## Geometry Collections
 

--- a/middle.mkd
+++ b/middle.mkd
@@ -201,8 +201,9 @@ A line between two positions is a straight Cartesian line, the shortest
 line between those two points in the Coordinate Reference System (see
 #[](#coordinate-reference-system)).
 
-In other words, every point on a line between a point (lon0, lat0) and
-(lon1, lat1) can be calculated as
+In other words, every point on a line that does not cross the
+antimeridian between a point (lon0, lat0) and (lon1, lat1) can be
+calculated as
 
     F(lon, lat) = (lon0 + (lon1 - lon0) * t, lat0 + (lat1 - lat0) * t)
 
@@ -406,11 +407,12 @@ with 0 <= t <= 1.
 ## The Antimeridian
 
 Consider a set of point features within the Fiji archipelago, straddling
-the antimeridian between 16°S and 20°S. The southwest corner of the box
-containing these features is at 20°S and 177°E, the northwest corner is
-at 16°S and 178°W. In the default GeoJSON CRS (see
-[](#coordinate-reference-system)) the antimeridian-spanning GeoJSON
-bounding box for this feature collection is
+the antimeridian between 16 degrees S and 20 degrees S. The southwest
+corner of the box containing these features is at 20 degrees S and 177
+degrees E, the northwest corner is at 16 degrees S and 178 degrees W. In
+the default GeoJSON CRS (see [](#coordinate-reference-system)) the
+antimeridian-spanning GeoJSON bounding box for this feature collection
+is
 
     "bbox": [177.0, -20.0, -178.0, -16.0]
 


### PR DESCRIPTION
The original bounding box section in Considerations is obsolete since we've added new guidance in the main body of the spec. I've replaced the fuzzy recommendations about what to do at the antimeridian with a clear recommendation to cut geometries. Examples included.