### PR TITLE
Clarify that negative heights are expected

### DIFF
--- a/middle.mkd
+++ b/middle.mkd
@@ -327,9 +327,9 @@ coordinate reference system is equivalent to the OGC's
 "http://www.opengis.net/def/crs/OGC/1.3/CRS84" [OGCURL]. To maximize
 interoperability, GeoJSON data SHOULD use this default coordinate
 reference system.  An OPTIONAL third position element SHALL be the
-height in meters above the WGS 84 reference ellipsoid. In the absence of
-elevation values, applications sensitive to height or depth SHOULD
-interpret positions as being at local ground or sea level.
+height in meters above or below the WGS 84 reference ellipsoid. In the
+absence of elevation values, applications sensitive to height or depth
+SHOULD interpret positions as being at local ground or sea level.
 
 Other coordinate reference systems, including ones described by CRS
 objects of the kind defined in [GJ2008] are NOT RECOMMENDED. GeoJSON


### PR DESCRIPTION
This is the proposed text from [Alissa Cooper's email](https://mailarchive.ietf.org/arch/msg/geojson/dK5vSfGSXCuWR7QkzQulk2yicMs).  I think it is implied that positive values imply distances above and negative below.  Not sure if there is need for further clarification there.
