### PR TITLE
Change "SHOULD" to "should" in 10.4

### DIFF
--- a/considerations.mkd
+++ b/considerations.mkd
@@ -57,7 +57,7 @@ longitude, latitude order.
 In representing features that cross the antimeridian, interoperability
 is improved by cutting geometries so that no single part crosses the
 antimeridian. For example, a line extending from 45 degrees N, 170
-degrees E across the antimeridian to 45 degrees N, 170 degrees W SHOULD
+degrees E across the antimeridian to 45 degrees N, 170 degrees W should
 be cut in two and represented as a MultiLineString.
 
     {
@@ -72,7 +72,7 @@ be cut in two and represented as a MultiLineString.
     }
 
 A rectangle extending from 40 degrees N, 170 degrees E across the
-antimeridian to 50 degrees N, 170 degrees W SHOULD be cut in two and
+antimeridian to 50 degrees N, 170 degrees W should be cut in two and
 represented as a MultiPolygon.
 
     {


### PR DESCRIPTION
This follows the suggestions from [Alissa Cooper's email](https://mailarchive.ietf.org/arch/msg/geojson/dK5vSfGSXCuWR7QkzQulk2yicMs).  I'll admit I don't understand the nuance here, but am curious to understand.

Note that we still have other RFC2119 key words in the considerations sections (including SHOULD).