### PR TITLE
Explain historical exceptions to position requirements

### DIFF
--- a/middle.mkd
+++ b/middle.mkd
@@ -189,14 +189,19 @@ member of a geometry object is composed of either:
 
 * or an array of Polygon coordinates in the case of a MultiPolygon geometry.
 
-A position is an array of numbers. There MUST be two or
-more elements. The first two elements are longitude and latitude,
-or easting and northing, precisely in that order and using decimal numbers.
-Altitude or elevation MAY be included as an optional third element.
+A position is an array of numbers. There MUST be two or more elements.
+The first two elements are longitude and latitude, or easting and
+northing, precisely in that order and using decimal numbers.  Altitude
+or elevation MAY be included as an optional third element.
 
-Implementations SHOULD NOT extend positions beyond 3 elements. Parsers
-MAY ignore additional elements. Interpretation and meaning of additional
-elements is beyond the scope of this specification.
+Implementations SHOULD NOT extend positions beyond 3 elements because
+the semantics of extra elements are unspecified and ambiguous.
+Historically, some implementations have used a 4th element to carry
+a linear referencing measure (sometimes denoted as "M") or a numerical
+timestamp, but in most situations a parser will not be able to properly
+interpret these values. The interpretation and meaning of additional
+elements is beyond the scope of this specification and additional
+elements MAY be ignored by parsers.
 
 A line between two positions is a straight Cartesian line, the shortest
 line between those two points in the Coordinate Reference System (see


### PR DESCRIPTION
Addressing the first comment in https://mailarchive.ietf.org/arch/msg/geojson/dK5vSfGSXCuWR7QkzQulk2yicMs.

> "Implementations SHOULD NOT extend positions beyond 3 elements.
   Parsers MAY ignore additional elements.  Interpretation and meaning
   of additional elements is beyond the scope of this specification."

> Since this is given as a SHOULD NOT I assume there are exception cases envisioned where implementations will specify more than 3 elements. What kind of circumstances might give rise to those exception cases? It would be good to provide some explanation in the spec.