### PR TITLE
Remove wording that requires CRS to be identified.

### DIFF
--- a/considerations.mkd
+++ b/considerations.mkd
@@ -35,23 +35,6 @@ geoid; with the WGS 84 [WGS84] height varying by up to 5m (but generally
 between 2 and 3 meters) higher or lower relative to a surface parallel
 to Earth's mean sea level.
 
-## Coordinate Order
-
-There are conflicting precedents among geographic data formats over
-whether latitude or longitude come first in a pair of numbers.
-Longitude comes first in GeoJSON coordinates as it does in [KMLv2.2].
-
-Some commonly-used CRS definitions specify coordinate ordering that is
-not longitude then latitude (for a geographic CRS) or easting then
-northing (for a projected CRS). The CRS historically known as
-"EPSG:4326" and more accurately identified by
-"http://www.opengis.net/def/crs/EPSG/0/4326" is a prime example.  Using
-such a CRS is NOT RECOMMENDED due to the potential disruption of
-interoperability. When such a CRS is encountered in GeoJSON, the
-document should be processed with caution.  Heuristics may be necessary
-to interpret the coordinates properly; they may not be in the required
-longitude, latitude order.
-
 ## Antimeridian Cutting
 
 In representing features that cross the antimeridian, interoperability

--- a/middle.mkd
+++ b/middle.mkd
@@ -332,7 +332,7 @@ absence of elevation values, applications sensitive to height or depth
 SHOULD interpret positions as being at local ground or sea level.
 
 Other coordinate reference systems are NOT RECOMMENDED. GeoJSON
-processing software SHALL NOT be expected to have access to coordinate
+processing software cannot be expected to have access to coordinate
 reference system databases or be expected to parse and interpret the CRS
 objects described in [GJ2008]. Furthermore, to prevent coordinate order
 confusion for parsers that do not have a CRS database, GeoJSON

--- a/middle.mkd
+++ b/middle.mkd
@@ -331,14 +331,17 @@ height in meters above or below the WGS 84 reference ellipsoid. In the
 absence of elevation values, applications sensitive to height or depth
 SHOULD interpret positions as being at local ground or sea level.
 
-Other coordinate reference systems, including ones described by CRS
-objects of the kind defined in [GJ2008] are NOT RECOMMENDED. GeoJSON
+Other coordinate reference systems are NOT RECOMMENDED. GeoJSON
 processing software SHALL NOT be expected to have access to coordinate
-reference systems databases. Applications requiring a CRS other than the
-default MUST assume all responsibility for CRS identification,
-coordinate accuracy, and interpretation of missing elevation values.
-Furthermore, GeoJSON coordinates MUST NOT under any circumstances use
-latitude, longitude order.
+reference system databases or be expected to parse and interpret the CRS
+objects described in [GJ2008]. Furthermore, to prevent coordinate order
+confusion for parsers that do not have a CRS database, GeoJSON
+coordinates MUST NOT under any circumstances use latitude, longitude
+order. For example, GeoJSON data using a coordinate reference system
+equivalent to "http://www.opengis.net/def/crs/EPSG/0/4326" [OGCURL]
+cannot be reliably distinguished from data using the default CRS and is
+not allowed. Applications using a CRS other than the default for
+specific purposes should contain this data as much as possible.
 
 # Bounding Box
 


### PR DESCRIPTION
Addressing the second comment in https://mailarchive.ietf.org/arch/msg/geojson/dK5vSfGSXCuWR7QkzQulk2yicMs.

> "Applications requiring a CRS
   other than the default MUST assume all responsibility for CRS
   identification, coordinate accuracy, and interpretation of missing
   elevation values."

> "MUST assume responsibility" is a bit of a strange construction for a normative requirement. I think I get what this is trying to accomplish, but I'm not sure it works as phrased. For coordinate accuracy and interpretation of missing values, I think the idea is really to warn implementors that they will have to fill in the gaps if they receive coordinates meant to be understood using a different CRS than what the application is using. Is that right? If so, I think this should just be phrased as a warning, without the normative requirement.

> CRS identification is a bit trickier, because it is included in [GJ2008] but not here, so this sort of sounds like it could be recommending use of the crs parameter as specified in [GJ2008] while also not incorporating that into this spec (for an unspecified reason). If you really want to require implementations to identify the CRS if they're not using the default, then I would think a way to do so (a la [GJ2008]) should be included in this spec. If not, then it seems inappropriate to normatively require that the CRS be identified; a non-normative recommendation would do instead, I think. Note that the decision of what to do here also has bearing on Section 10.3, which basically assumes that the CRS will be identified.

I've removed any normative requirement that CRS be identified. I've also added an example of a CRS that is not supported because of its coordinate order conflict with the default, which in my view makes section 10.3 superfluous and removable.

Lastly, I've advised producers of specialized GeoJSON (I am one of them and use projected GeoJSON within a particular data processing pipeline at work) to not let it leak out onto the internet.

@coopdanger how about this change? @mpdaly also pinging you because you had a lot of input on the original text: does the specific example against EPSG:4326 help?

/cc @martinthomson @dret