### PR TITLE
One editor, new contributors section.

### DIFF
--- a/back.mkd
+++ b/back.mkd
@@ -211,14 +211,3 @@ specification [GJ2008].
 All GeoJSON objects defined in this specification - FeatureCollection, Feature, and Geometry - consist of exactly one JSON object. However, there may be circumstances in which applications need to represent sets or sequences of these objects (over and above the grouping of Feature objects in a FeatureCollection), e.g. in order to efficiently "stream" large numbers of Feature objects. The definition of such sets or sequences is outside the scope of this specification.
 
 If such a representation is needed, a new media type is required that has the ability to represent these sets or sequences. When defining such a media type, it may be useful to base it on "JSON Text Sequences" [RFC7464], leaving the foundations of how to represent multiple JSON objects to that specification, and only defining how it applies to GeoJSON objects.
-
-
-# Contributors
-
-The GeoJSON format is the product of discussion on the GeoJSON mailing
-list, http://lists.geojson.org/listinfo.cgi/geojson-geojson.org, before
-October 2015 and the IETF's GeoJSON WG after October 2015.
-
-Comments are solicited and should be addressed to the GeoJSON mailing
-list at geojson@ietf.org or to the GeoJSON issue tracker at
-https://github.com/geojson/draft-geojson/issues.

--- a/middle.mkd
+++ b/middle.mkd
@@ -530,7 +530,7 @@ feature object below
 
 the "centerline" member is not a GeoJSON geometry object.
 
-#IGeoJSON Types are not Extensible
+# GeoJSON Types are not Extensible
 
 Implementations MUST NOT extend the fixed set of GeoJSON types:
 FeatureCollection, Feature, Point, LineString, MultiPoint, Polygon,

--- a/template.xml
+++ b/template.xml
@@ -111,7 +111,7 @@
    </section>
 
   <section title="Contributors">
-  <t>The GeoJSON draft is primarily the work of the following individuals:</t>
+  <t>The GeoJSON draft is primarily the work of the following individuals:
 
   <list style="none">
   <t>Howard Butler<vspace/>Hobu Inc.<vspace blankLines="1"/>Email: howard@hobu.co<vspace blankLines="1"/></t>
@@ -120,6 +120,7 @@
   <t>Tim Schaub<vspace/>Planet Labs<vspace blankLines="1"/>Email: tim.schaub@gmail.com<vspace blankLines="1"/></t>
   <t>Stefan Hagen<vspace/>Rheinaustr. 62<vspace/>Bonn 53225<vspace/>DE<vspace/><vspace blankLines="1"/>Email: stefan@hagen.link<vspace/>URI: http://stefan-hagen.website/<vspace blankLines="1"/></t>
   </list>
+  </t>
 
   </section>
   <section title="Acknowledgements">

--- a/template.xml
+++ b/template.xml
@@ -126,7 +126,6 @@
   <t>The GeoJSON format is the product of discussion on the GeoJSON mailing
 list, http://lists.geojson.org/listinfo.cgi/geojson-geojson.org, before
 October 2015 and the IETF's GeoJSON WG after October 2015.</t>
-
   <t>Material in this document was adapted with changes from http://geojson.org/geojson-spec.html [GJ2008] which is licensed under http://creativecommons.org/licenses/by/3.0/us/.</t>
   </section>
 

--- a/template.xml
+++ b/template.xml
@@ -17,7 +17,7 @@
 <!ENTITY pandocRef7493  PUBLIC '' 'bib/reference.RFC.7493.xml'>
 ]>
 
-<rfc ipr="trust200902" category="std" docName="draft-ietf-geojson-01">
+<rfc ipr="trust200902" category="std" docName="draft-ietf-geojson-03">
 <?rfc toc="yes"?>         <!-- generate a table of contents -->
 <?rfc symrefs="yes"?>     <!-- use anchors instead of numbers for references -->
 <?rfc sortrefs="yes" ?>   <!-- alphabetize the references -->
@@ -26,8 +26,8 @@
  <front>
         <title abbrev="GeoJSON">The GeoJSON Format</title>
 
-        <author initials="S." surname="Gillies"
-                fullname="Sean Gillies, Editor">
+        <author initials="S." surname="Gillies" fullname="Sean Gillies"
+                role="editor">
             <organization>Mapbox</organization>
             <address>
                 <postal>
@@ -111,22 +111,23 @@
    </section>
 
   <section title="Contributors">
-  <t>The GeoJSON draft is primarily the work of the following individuals.</t>
-  
+  <t>The GeoJSON draft is primarily the work of the following individuals:</t>
+
+  <list style="none">
   <t>Howard Butler<vspace/>Hobu Inc.<vspace blankLines="1"/>Email: howard@hobu.co<vspace blankLines="1"/></t>
   <t>Martin Daly<vspace/>Cadcorp<vspace blankLines="1"/>Email: martin.daly@cadcorp.com<vspace blankLines="1"/></t>
-  <t>Allan Doyle<vspace/>MIT<vspace blankLines="1"/>Email: adoyle@intl-interfaces.com<vspace blankLines="1"/></t>
+  <t>Allan Doyle<vspace blankLines="1"/>Email: adoyle@intl-interfaces.com<vspace blankLines="1"/></t>
   <t>Tim Schaub<vspace/>Planet Labs<vspace blankLines="1"/>Email: tim.schaub@gmail.com<vspace blankLines="1"/></t>
   <t>Stefan Hagen<vspace/>Rheinaustr. 62<vspace/>Bonn 53225<vspace/>DE<vspace/><vspace blankLines="1"/>Email: stefan@hagen.link<vspace/>URI: http://stefan-hagen.website/<vspace blankLines="1"/></t>
+  </list>
 
   </section>
   <section title="Acknowledgements">
   <t>The GeoJSON format is the product of discussion on the GeoJSON mailing
 list, http://lists.geojson.org/listinfo.cgi/geojson-geojson.org, before
 October 2015 and the IETF's GeoJSON WG after October 2015.</t>
-  <t>Comments are solicited and should be addressed to the GeoJSON mailing
-list at geojson@ietf.org or to the GeoJSON issue tracker at
-https://github.com/geojson/draft-geojson/issues.</t>
+
+  <t>Material in this document was adapted with changes from http://geojson.org/geojson-spec.html [GJ2008] which is licensed under http://creativecommons.org/licenses/by/3.0/us/.</t>
   </section>
 
 </middle>

--- a/template.xml
+++ b/template.xml
@@ -26,59 +26,19 @@
  <front>
         <title abbrev="GeoJSON">The GeoJSON Format</title>
 
-        <author initials="H." surname="Butler"
-                fullname="H. Butler">
-            <organization>Hobu Inc.</organization>
-            <address>
-                <email>howard@hobu.co</email>
-            </address>
-        </author>
-        <author initials="M." surname="Daly"
-                fullname="M. Daly">
-            <organization>Cadcorp</organization>
-            <address>
-                <email>martin.daly@cadcorp.com</email>
-            </address>
-        </author>
-        <author initials="A." surname="Doyle"
-                fullname="A. Doyle">
-            <organization>MIT</organization>
-            <address>
-                <email>adoyle@intl-interfaces.com</email>
-            </address>
-        </author>
         <author initials="S." surname="Gillies"
-                fullname="S. Gillies">
-            <organization>Mapbox Inc.</organization>
+                fullname="Sean Gillies, Editor">
+            <organization>Mapbox</organization>
             <address>
+                <postal>
+                    <street>1714 14th St NW, Rear Entrance</street>
+                    <city>Washington</city><region>DC</region><code>20009</code>
+                </postal>
                 <email>sean.gillies@gmail.com</email>
                 <uri>http://sgillies.net</uri>
             </address>
+        </author>
 
-        </author>
-        <author initials="T." surname="Schaub"
-                fullname="T. Schaub">
-            <organization>Planet Labs</organization>
-            <address>
-                <email>tim.schaub@gmail.com</email>
-            </address>
-        </author>
-        <author initials="S." surname="Hagen"
-                fullname="S. Hagen">
-            <address>
-                <postal>
-                    <street>Rheinaustr. 62</street>
-                    <street></street>
-                    <city>Bonn</city> <region></region>
-                    <code>53225</code>
-                    <country>DE</country>
-                </postal>
-
-                <phone></phone>
-                <email>stefan@hagen.link</email>
-                <uri>http://stefan-hagen.website/</uri>
-            </address>
-        </author>
         <date day="06" month="March" year="2016"/>
 
         <area>Applications and Real-Time Area (art)</area>
@@ -107,6 +67,7 @@
 <middle>
 &pandocMiddle;
 &pandocConsiderations;
+
    <section title="IANA Considerations">
        <t>
        The media type for GeoJSON text is <spanx
@@ -148,6 +109,26 @@
         </list>
        </t>
    </section>
+
+  <section title="Contributors">
+  <t>The GeoJSON draft is primarily the work of the following individuals.</t>
+  
+  <t>Howard Butler<vspace/>Hobu Inc.<vspace blankLines="1"/>Email: howard@hobu.co<vspace blankLines="1"/></t>
+  <t>Martin Daly<vspace/>Cadcorp<vspace blankLines="1"/>Email: martin.daly@cadcorp.com<vspace blankLines="1"/></t>
+  <t>Allan Doyle<vspace/>MIT<vspace blankLines="1"/>Email: adoyle@intl-interfaces.com<vspace blankLines="1"/></t>
+  <t>Tim Schaub<vspace/>Planet Labs<vspace blankLines="1"/>Email: tim.schaub@gmail.com<vspace blankLines="1"/></t>
+  <t>Stefan Hagen<vspace/>Rheinaustr. 62<vspace/>Bonn 53225<vspace/>DE<vspace/><vspace blankLines="1"/>Email: stefan@hagen.link<vspace/>URI: http://stefan-hagen.website/<vspace blankLines="1"/></t>
+
+  </section>
+  <section title="Acknowledgements">
+  <t>The GeoJSON format is the product of discussion on the GeoJSON mailing
+list, http://lists.geojson.org/listinfo.cgi/geojson-geojson.org, before
+October 2015 and the IETF's GeoJSON WG after October 2015.</t>
+  <t>Comments are solicited and should be addressed to the GeoJSON mailing
+list at geojson@ietf.org or to the GeoJSON issue tracker at
+https://github.com/geojson/draft-geojson/issues.</t>
+  </section>
+
 </middle>
 
 <back>


### PR DESCRIPTION
An attempt to address "Author Overload", which the RFC Editor is sure to recognize in our draft. See https://www.rfc-editor.org/old/policy.html#policy.authlist. Makes sense to me.

As you can see, I've created a new Contributors section and moved author names, affiliations, and contact info there. I've also made it clear that this is their work.

Pandoc2rfc was letting me down on the author listing, so I reverted to XML.

/cc @martinthomson @dret