### PR TITLE
Remove guidance on CRS other than CRS84

### DIFF
--- a/back.mkd
+++ b/back.mkd
@@ -161,8 +161,8 @@ specification [GJ2008].
 
 ## Normative Changes
 
-* Specification of coordinate reference systems, i.e., the "crs" member
-  has been removed.
+* Specification of coordinate reference systems has been removed, i.e.,
+  the "crs" member of [GJ2008] is no longer used.
 
 * In the absence of elevation values, applications sensitive to height
   or depth SHOULD interpret positions as being at local ground or sea

--- a/back.mkd
+++ b/back.mkd
@@ -161,7 +161,8 @@ specification [GJ2008].
 
 ## Normative Changes
 
-* Coordinate reference systems other than the default MUST NOT be used.
+* Specification of coordinate reference systems, i.e., the "crs" member
+  has been removed.
 
 * In the absence of elevation values, applications sensitive to height
   or depth SHOULD interpret positions as being at local ground or sea

--- a/back.mkd
+++ b/back.mkd
@@ -161,8 +161,7 @@ specification [GJ2008].
 
 ## Normative Changes
 
-* Coordinate reference systems other than the default are NOT
-  RECOMMENDED (see [](#coordinate-reference-system)).
+* Coordinate reference systems other than the default MUST NOT be used.
 
 * In the absence of elevation values, applications sensitive to height
   or depth SHOULD interpret positions as being at local ground or sea

--- a/considerations.mkd
+++ b/considerations.mkd
@@ -34,20 +34,3 @@ Furthermore the default WGS 84 [WGS84] datum uses a relatively coarse
 geoid; with the WGS 84 [WGS84] height varying by up to 5m (but generally
 between 2 and 3 meters) higher or lower relative to a surface parallel
 to Earth's mean sea level.
-
-## Coordinate Order
-
-There are conflicting precedents among geographic data formats over
-whether latitude or longitude come first in a pair of numbers.
-Longitude comes first in GeoJSON coordinates as it does in [KMLv2.2].
-
-Some commonly-used CRS definitions specify coordinate ordering that is
-not longitude then latitude (for a geographic CRS) or easting then
-northing (for a projected CRS). The CRS historically known as
-"EPSG:4326" and more accurately identified by
-"http://www.opengis.net/def/crs/EPSG/0/4326" is a prime example.  Using
-such a CRS is NOT RECOMMENDED due to the potential disruption of
-interoperability. When such a CRS is encountered in GeoJSON, the
-document should be processed with caution.  Heuristics may be necessary
-to interpret the coordinates properly; they may not be in the required
-longitude, latitude order.

--- a/middle.mkd
+++ b/middle.mkd
@@ -214,19 +214,16 @@ calculated as
     F(lon, lat) = (lon0 + (lon1 - lon0) * t, lat0 + (lat1 - lat0) * t)
 
 with t a real number greater or equal to 0 and smaller or equal to 1.
-
-Note that - for example in the WGS 84 datum [WGS84], the default
-Coordinate Reference System - this line may markedly differ from the
-geodesic path along the curved surface of the reference ellipsoid.
+Note that this line may markedly differ from the geodesic path along the
+curved surface of the reference ellipsoid.
 
 The same applies to the optional height element with the proviso that
 the direction of the height is as specified in the Coordinate Reference
 System.
 
-Note that, again, using the default WGS 84 datum as a starting point,
-this does not mean that a surface with equal height follows, for
-example, the curvature of a body of water. Nor is a surface of equal
-height perpendicular to a plumb line.
+Note that, again, this does not mean that a surface with equal height
+follows, for example, the curvature of a body of water. Nor is a surface
+of equal height perpendicular to a plumb line.
 
 Examples of positions and geometries are provided in "Appendix A.
 Geometry Examples".
@@ -401,25 +398,16 @@ possible for this array to be empty.
 
 # Coordinate Reference System
 
-The default reference system for all GeoJSON coordinates SHALL be
+The coordinate reference system for all GeoJSON coordinates SHALL be
 a geographic coordinate reference system, using the WGS 84 [WGS84]
 datum, and with longitude and latitude units of decimal degrees. This
 coordinate reference system is equivalent to the OGC's
-"http://www.opengis.net/def/crs/OGC/1.3/CRS84" [OGCURL]. To maximize
-interoperability, GeoJSON data SHOULD use this default coordinate
-reference system.  An OPTIONAL third position element SHALL be the
-height in meters above or below the WGS 84 reference ellipsoid. In the
-absence of elevation values, applications sensitive to height or depth
-SHOULD interpret positions as being at local ground or sea level.
-
-Other coordinate reference systems, including ones described by CRS
-objects of the kind defined in [GJ2008] are NOT RECOMMENDED. GeoJSON
-processing software SHALL NOT be expected to have access to coordinate
-reference systems databases. Applications requiring a CRS other than the
-default MUST assume all responsibility for CRS identification,
-coordinate accuracy, and interpretation of missing elevation values.
-Furthermore, GeoJSON coordinates MUST NOT under any circumstances use
-latitude, longitude order.
+"http://www.opengis.net/def/crs/OGC/1.3/CRS84" [OGCURL]. An OPTIONAL
+third position element SHALL be the height in meters above or below the
+WGS 84 reference ellipsoid. In the absence of elevation values,
+applications sensitive to height or depth SHOULD interpret positions as
+being at local ground or sea level. GeoJSON documents MUST NOT use
+a coordinate reference system other than the one defined here.
 
 # Bounding Box
 
@@ -431,8 +419,7 @@ geometries, with all axes of the most south-westerly point followed by
 all axes of the more north-easterly point. The axes order of a bbox
 follows the axes order of geometries.
 
-In the default GeoJSON CRS (see [](#coordinate-reference-system)), the
-"bbox" values define shapes with edges that follow lines of constant
+The "bbox" values define shapes with edges that follow lines of constant
 longitude, latitude, and elevation.
 
 Example of a 2D bbox member on a feature:
@@ -489,10 +476,9 @@ with 0 <= t <= 1.
 Consider a set of point features within the Fiji archipelago, straddling
 the antimeridian between 16 degrees S and 20 degrees S. The southwest
 corner of the box containing these features is at 20 degrees S and 177
-degrees E, the northwest corner is at 16 degrees S and 178 degrees W. In
-the default GeoJSON CRS (see [](#coordinate-reference-system)) the
-antimeridian-spanning GeoJSON bounding box for this feature collection
-is
+degrees E, the northwest corner is at 16 degrees S and 178 degrees W.
+The antimeridian-spanning GeoJSON bounding box for this feature
+collection is
 
     "bbox": [177.0, -20.0, -178.0, -16.0]
 
@@ -510,11 +496,9 @@ of the southwest corner, but bounding boxes that cross the antimeridian
 have a northeast corner longitude that is less than the longitude of the
 southwest corner.
 
-
 ## The Poles
 
-In the default GeoJSON CRS (see [](#coordinate-reference-system)),
-a bounding box that contains the North Pole extends from a southwest
+A bounding box that contains the North Pole extends from a southwest
 corner of %minlat% degrees N, 180 degrees W to a northeast corner of 90
 degrees N, 180 degrees E. Viewed on a globe, this bounding box
 approximates a spherical cap.
@@ -542,8 +526,7 @@ corner coordinates the westernmost longitude value and 90 degrees S.
     "bbox": [%westlon%, -90.0, %eastlon%, %maxlat%]
 
 Implementers MUST NOT use latitude values greater than 90 or less than
--90 when using the default GeoJSON coordinate reference system to imply
-an extent that is not a spherical cap.
+-90 to imply an extent that is not a spherical cap.
 
 # Extending GeoJSON
 

--- a/middle.mkd
+++ b/middle.mkd
@@ -398,7 +398,7 @@ possible for this array to be empty.
 
 # Coordinate Reference System
 
-The coordinate reference system for all GeoJSON coordinates SHALL be
+The coordinate reference system for all GeoJSON coordinates is
 a geographic coordinate reference system, using the WGS 84 [WGS84]
 datum, and with longitude and latitude units of decimal degrees. This
 coordinate reference system is equivalent to the OGC's

--- a/middle.mkd
+++ b/middle.mkd
@@ -409,13 +409,15 @@ applications sensitive to height or depth SHOULD interpret positions as
 being at local ground or sea level.
 
 Note: the use of alternative coordinate reference systems was specified
-in [GJ2008], but has been removed from the present version of the
+in [GJ2008], but has been removed from this version of the
 specification because the use of different coordinate reference systems
-has proven to have interoperability issues. In general, GeoJSON
-processing software cannot be expected to have access to coordinate
-reference systems databases. However, where all involved parties have
-a prior arrangement, alternative coordinate reference systems can be
-used without risk of data being misinterpreted.
+-- especially in the manner specified in [GJ2008] -- has proven to have
+interoperability issues. In general, GeoJSON processing software is not
+expected to have access to coordinate reference systems databases or
+to to have network access to coordinate reference system transformation
+parameters. However, where all involved parties have a prior
+arrangement, alternative coordinate reference systems can be used
+without risk of data being misinterpreted.
 
 # Bounding Box
 

--- a/middle.mkd
+++ b/middle.mkd
@@ -406,8 +406,16 @@ coordinate reference system is equivalent to the OGC's
 third position element SHALL be the height in meters above or below the
 WGS 84 reference ellipsoid. In the absence of elevation values,
 applications sensitive to height or depth SHOULD interpret positions as
-being at local ground or sea level. GeoJSON documents MUST NOT use
-a coordinate reference system other than the one defined here.
+being at local ground or sea level.
+
+Note: the use of alternative coordinate reference systems was specified
+in [GJ2008], but has been removed from the present version of the
+specification because the use of different coordinate reference systems
+has proven to have interoperability issues. In general, GeoJSON
+processing software cannot be expected to have access to coordinate
+reference systems databases. However, where all involved parties have
+a prior arrangement, alternative coordinate reference systems can be
+used without risk of data being misinterpreted.
 
 # Bounding Box
 


### PR DESCRIPTION
Interest in strictly requiring CRS84 is increasing. It would let us shrink the spec, eliminate arbitrariness and pointless arguments, and does no harm to those who weren't going to follow the spec in the first place. Carl Reed has pointed out that the Common Alert Protocol uses a single CRS. KML also uses a single CRS (KML's decreasing popularity has nothing to do with this requirement as far as I can tell).

Those that were depending on support for other CRS and are using the old CRS objects http://geojson.org/geojson-spec.html#coordinate-reference-system-objects should be little impacted: GDAL isn't going to stop supporting the old CRS object overnight, and support for the old GeoJSON CRS objects in newer software and applications is very rare.