### PR TITLE
Correct section numbers

### DIFF
--- a/template.xml
+++ b/template.xml
@@ -120,8 +120,8 @@
          <t hangText="Required parameters:">n/a</t>
          <t hangText="Optional parameters:">n/a</t>
          <t hangText="Encoding considerations:">binary</t>
-         <t hangText="Security considerations:">See section 9 above</t>
-         <t hangText="Interoperability considerations:">See section 10 above</t>
+         <t hangText="Security considerations:">See section 10 above</t>
+         <t hangText="Interoperability considerations:">See section 11 above</t>
          <t hangText="Published specification:">[[This document]]</t>
          <t hangText="Applications that use this media type:">various</t>
          <t hangText="Additional information:">

--- a/template.xml
+++ b/template.xml
@@ -120,8 +120,8 @@
          <t hangText="Required parameters:">n/a</t>
          <t hangText="Optional parameters:">n/a</t>
          <t hangText="Encoding considerations:">binary</t>
-         <t hangText="Security considerations:">See section 10 above</t>
-         <t hangText="Interoperability considerations:">See section 11 above</t>
+         <t hangText="Security considerations:">See <xref target="security-considerations" pageno="false" format="default"/> above</t>
+         <t hangText="Interoperability considerations:">See <xref target="interoperability-considerations" pageno="false" format="default"/> above</t>
          <t hangText="Published specification:">[[This document]]</t>
          <t hangText="Applications that use this media type:">various</t>
          <t hangText="Additional information:">


### PR DESCRIPTION
This corrects the section numbers referenced in the IANA Considerations.

I haven't dug into how this whole thing is assembled, but I'm wondering if there is another way to link things together without manually maintaining the section numbers in `template.xml`.

Maybe unrelated, but I'm also curious if [`media-type/registration.md`](https://github.com/geojson/draft-geojson/blob/a8ed7b5f4834ad8af8ad9c74d8f80c32408561f4/media-type/registration.md) is no longer used (it uses application/vnd.geo+json).