### PR TITLE
Standard winding order for newly created GeoJSON

### DIFF
--- a/back.mkd
+++ b/back.mkd
@@ -174,6 +174,9 @@ specification [GJ2008].
 * A line between two positions is a straight Cartesian line (see
   [](#position)).
 
+* Polygon rings MUST follow the right-hand rule for orientation
+  (counter-clockwise external rings, clockwise internal rings).
+
 * The values of a "bbox" array are `[%west%, %south%, %east%, %north%]`,
   not `[%minx%, %miny%, %maxx%, %maxy%]` (see [](#bounding-box)).
 
@@ -198,10 +201,6 @@ specification [GJ2008].
 
 * Implementers are cautioned about the effect of excessive coordinate
   precision on interoperability.
-
-* Right-hand rule orientation of polygon rings (counter-clockwise
-  external rings, clockwise internal rings) is recommended to improve
-  interoperability.
 
 * Interoperability concerns of geometry collections are noted. These
   objects should be used sparingly (see [](#geometry-collection)).

--- a/middle.mkd
+++ b/middle.mkd
@@ -260,9 +260,13 @@ the concept of a linear ring:
 * A linear ring is the boundary of a surface or the boundary of a hole in
   a surface.
 
-* A linear ring SHOULD follow the right-hand rule with respect to the area
+* A linear ring MUST follow the right-hand rule with respect to the area
   it bounds (i.e., exterior rings are counter-clockwise, holes are
-  clockwise)
+  clockwise).
+
+Note: the [GJ2008] specification did not discuss linear ring winding order.
+For backwards compatibility, parsers SHOULD NOT reject polygons that do not
+follow the right-hand rule.
 
 Though a linear ring is not explicitly represented as a GeoJSON geometry
 type, it leads to a canonical formulation of the Polygon geometry type


### PR DESCRIPTION
Following Ben Campbell's comments, this suggests specifying that rings MUST follow the right-hand rule (and parsers SHOULD accept left-handed rings where backwards compatibility is a concern).