### PR TITLE
Assorted corrections

### DIFF
--- a/back.mkd
+++ b/back.mkd
@@ -180,7 +180,7 @@ specification [GJ2008].
 * A Feature object's "id" member is a string or number (see
   [](#feature-object)).
 
-* Extensions MAY be used, but MUST NOT change the the semantics of
+* Extensions MAY be used, but MUST NOT change the semantics of
   GeoJSON members and types (see [](#extending-geojson)).
 
 * GeoJSON objects MUST NOT contain the defining members of other types

--- a/charter.md
+++ b/charter.md
@@ -6,7 +6,7 @@ GeoJSON
 
 GeoJSON is a format for encoding data about geographic features using
 JavaScript Object Notation (JSON) [RFC7159]. Geographic features need not be
-physical things; any thing with properties that are bounded in space may be
+physical things; anything with properties that are bounded in space may be
 considered a feature. GeoJSON provides a means of representing both the
 properties and spatial extent of features.
 

--- a/middle.mkd
+++ b/middle.mkd
@@ -358,11 +358,11 @@ As per [RFC7459] no measure of location uncertainty or confidence can be
 known for "Point", "MultiPoint", "LineString", or "MultiLineString"
 geometry types.
 
-Applications such as PIDF-LO that are sensitive to location uncertainty
-and confidence might treat a geometry object of type "Polygon",
-"MultiPolygon", and "GeometryCollection" as a representation of a 95%
-confidence surface. In probabilistic terms: 95 percent of the location's
-point set is contained within the GeoJSON geometry.
+Applications such as Presence Information Data Format Location Object (PIDF-LO)
+[RFC5139] that are sensitive to location uncertainty and confidence might treat
+a geometry object of type "Polygon", "MultiPolygon", and "GeometryCollection"
+as a representation of a 95% confidence surface. In probabilistic terms: 95
+percent of the location's point set is contained within the GeoJSON geometry.
 
 As in [RFC5870] the number of digits of the values in coordinate
 positions MUST NOT be interpreted as an indication to the level of

--- a/middle.mkd
+++ b/middle.mkd
@@ -29,11 +29,10 @@ objects in GeoJSON contain a geometry object with one of the above
 geometry types and additional members. A FeatureCollection object
 contains an array of feature objects. This structure is analogous to
 that of the Web Feature Service (WFS) response to GetFeatures requests
-specified in [WFSv1] or to a KML Folder of Placemarks [KMLv2.2]. Some
-implementations of the WFS specification also provide GeoJSON formatted
-responses to GetFeature requests, but there is no particular service
-model or feature type ontology implied in the GeoJSON format
-specification.
+specified in [WFSv1] or to a Keyhole Markup Language (KML) Folder of Placemarks
+[KMLv2.2]. Some implementations of the WFS specification also provide GeoJSON
+formatted responses to GetFeature requests, but there is no particular service
+model or feature type ontology implied in the GeoJSON format specification.
 
 Since its initial publication in 2008 [GJ2008], the GeoJSON format
 specification has steadily grown in popularity. It is widely used in

--- a/middle.mkd
+++ b/middle.mkd
@@ -647,4 +647,4 @@ GeoJSON:
   {"type": "Point", "coordinates": [%lon%, %lat%, %alt%]}
 
 GeoJSON has no concept of uncertainty; imprecise or uncertain 'geo' URIs thus
-can not be mapped to GeoJSON geometries.
+cannot be mapped to GeoJSON geometries.

--- a/middle.mkd
+++ b/middle.mkd
@@ -413,7 +413,7 @@ specification because the use of different coordinate reference systems
 -- especially in the manner specified in [GJ2008] -- has proven to have
 interoperability issues. In general, GeoJSON processing software is not
 expected to have access to coordinate reference systems databases or
-to to have network access to coordinate reference system transformation
+to have network access to coordinate reference system transformation
 parameters. However, where all involved parties have a prior
 arrangement, alternative coordinate reference systems can be used
 without risk of data being misinterpreted.

--- a/middle.mkd
+++ b/middle.mkd
@@ -376,7 +376,7 @@ A Feature object represents a spatially-bounded thing.
 
 * A feature object MUST have a member with the name "geometry". The
   value of the geometry member SHALL be either a geometry object as
-  defined above or, in the the case that the feature is unlocated,
+  defined above or, in the case that the feature is unlocated,
   a JSON null value.
 
 * A feature object MUST have a member with the name "properties". The
@@ -590,7 +590,7 @@ MultiLineString, MultiPolygon, and GeometryCollection.
 
 ## Semantics of GeoJSON Members and Types are not Changeable
 
-Implementations MUST NOT change the the semantics of GeoJSON members and
+Implementations MUST NOT change the semantics of GeoJSON members and
 types.
 
 The GeoJSON "coordinates" and "geometries" members define Geometry


### PR DESCRIPTION
This addresses comments from Meral Shirazipour, Gen-ART reviewer:

> Nits/editorial comments:
> -[Page 3], "any thing"--typo-->"anything"

d5b8ebf83fe6d449e1541815b289694746762c59

> -[Page 4], KML not spelled out at first use (Keyhole Markup Language?)

120ad518c71d42935ff3dc36332425e2fdf23fd0

> -[Page 11],PIDF-LO, please spell out at first use and maybe reference RFC5139.

3dbe6069ce59f7cd17b592c605093ef72a3c84a7

> -[Page 11], it says
> "Applications such as PIDF-LO that are sensitive to location
>    uncertainty and confidence might treat ...
> "
> Not clear: if this is not an OK behavior, it should say "should not treat..."? If this is an ok behavior, maybe it should say "MAY treat ..."

I didn't change anything here.  I agree this paragraph adds confusion.  I think the section on Uncertainty and Confidence would be clearer if we removed it.

> -[Page 12], "in the the case"---typo-->"in the case"

b92cbfee74da0d675111e645562f612141f9b1ae (there were three of the same typo)

> -[Page 12], "the OGC's "http://www.opengis.net/def/crs/OGC/1.3/CRS84" [OGCURL]. "
> Should the URL  be moved to reference section?

~~As this is a URN, I don't think it is appropriate for the reference section (it doesn't resolve to anything useful).~~

Excuse me.  That is not a URN.  @dr-shorthair is that expected to resolve to the "Failed resolving http://www.opengis.netcrs/OGC/1.3/CRS84" document (see also #29)?

> -[Page 13], "or to to have"--typo-->"or to have"

3d9ca4b945ea11bafc28b8aa537ca816204dea2e

> -[Page 16], "the the semantics"--typo-->"the semantics"

b92cbfee74da0d675111e645562f612141f9b1ae

> -[Page 18], "can not be"---->"cannot be"

4753d5040a56351e02a8af47c433351eb2e81ad7