### PR TITLE
Revert to the URN since the URL resolves to a 404

### DIFF
--- a/middle.mkd
+++ b/middle.mkd
@@ -400,12 +400,11 @@ possible for this array to be empty.
 The coordinate reference system for all GeoJSON coordinates is
 a geographic coordinate reference system, using the WGS 84 [WGS84]
 datum, and with longitude and latitude units of decimal degrees. This
-coordinate reference system is equivalent to the OGC's
-"http://www.opengis.net/def/crs/OGC/1.3/CRS84" [OGCURL]. An OPTIONAL
-third position element SHALL be the height in meters above or below the
-WGS 84 reference ellipsoid. In the absence of elevation values,
-applications sensitive to height or depth SHOULD interpret positions as
-being at local ground or sea level.
+is equivalent to the coordinate reference system identified by the OGC
+URN urn:ogc:def:crs:OGC::CRS84. An OPTIONAL third position element SHALL
+be the height in meters above or below the WGS 84 reference ellipsoid.
+In the absence of elevation values, applications sensitive to height or
+depth SHOULD interpret positions as being at local ground or sea level.
 
 Note: the use of alternative coordinate reference systems was specified
 in [GJ2008], but has been removed from this version of the

--- a/template.xml
+++ b/template.xml
@@ -220,14 +220,6 @@
            </front>
            <seriesInfo name="OGC" value="07-147r2" />
        </reference>
-       <reference anchor="OGCURL">
-           <front>
-               <title>OGC-NA Name type specification - definitions: Part 1 - basic name</title>
-               <author initials="S.J.D." surname="Cox"></author>
-               <date month="March" year="2010" />
-           </front>
-           <seriesInfo name="OGC" value="09-048r3" />
-       </reference>
     </references>
     &pandocBack;
 </back>


### PR DESCRIPTION
The OGC white paper 10-124r1 (https://portal.opengeospatial.org/files/?artifact_id=39467) makes the case for using http URIs in place of URNs for coordinate reference system identifiers.  The document also notes it "is not an official position of the OGC membership on this particular topic."

In 5faae18fea350aa81f8802eae74269ea9901c5bf, the CRS URN were replaced with http://www.opengis.net/def/crs/OGC/1.3/CRS84.  I'm not sure if this was different at the time of the change, but today that URL is a 404 with some exception text.

I think it would be less confusing to those not familiar with the OGC if we didn't publish our spec with a URL that generates a 404.  And those familiar with the OGC will likely find the URN meaningful enough.

Fixes #209.