### PR TITLE
Eliminate use of % for variables

### DIFF
--- a/back.mkd
+++ b/back.mkd
@@ -177,8 +177,8 @@ specification [GJ2008].
 * Polygon rings MUST follow the right-hand rule for orientation
   (counter-clockwise external rings, clockwise internal rings).
 
-* The values of a "bbox" array are `[%west%, %south%, %east%, %north%]`,
-  not `[%minx%, %miny%, %maxx%, %maxy%]` (see [](#bounding-box)).
+* The values of a "bbox" array are "[west, south, east, north]",
+  not "[minx, miny, maxx, maxy]" (see [](#bounding-box)).
 
 * A Feature object's "id" member is a string or number (see
   [](#feature-object)).

--- a/middle.mkd
+++ b/middle.mkd
@@ -466,10 +466,11 @@ Example of a 3D bbox member with a depth of 100 meters:
 ## The Connecting Lines
 
 The 4 lines of the bounding box are defined fully within the coordinate
-reference system; i.e. every point on the northernmost line can be
+reference system; i.e. for a box bounded by the values "west", "south",
+"east", and "north" every point on the northernmost line can be
 expressed as
 
-    (lon, lat) = (%minlon% + (%maxlon% - %minlon%) * t, %maxlat%)
+    (lon, lat) = (west + (east - west) * t, north)
 
 with 0 <= t <= 1.
 
@@ -501,31 +502,30 @@ southwest corner.
 ## The Poles
 
 A bounding box that contains the North Pole extends from a southwest
-corner of %minlat% degrees N, 180 degrees W to a northeast corner of 90
+corner of "minlat" degrees N, 180 degrees W to a northeast corner of 90
 degrees N, 180 degrees E. Viewed on a globe, this bounding box
-approximates a spherical cap.
+approximates a spherical cap bounded by the "minlat" circle of latitude.
 
-    "bbox": [-180.0, %minlat%, 180.0, 90.0]
+    "bbox": [-180.0, minlat, 180.0, 90.0]
 
 A bounding box that contains the South Pole extends from a southwest
 corner of 90 degrees S, 180 degrees W to a northeast corner of
-%maxlat% degrees S, 180 degrees E.
+"maxlat" degrees S, 180 degrees E.
 
-    "bbox": [-180.0, -90.0, 180.0, %maxlat%]
+    "bbox": [-180.0, -90.0, 180.0, maxlat]
 
 A bounding box that just touches the North Pole and forms a slice of an
-approximate spherical cap when viewed on a globe has as its northeast
-corner coordinates the easternmost longitude value and 90 degrees N.
+approximate spherical cap when viewed on a globe extends from
+a southwest corner of "minlat" degrees N and "westlon" degrees E to
+a northeast corner of 90 degrees N and "eastlon" degrees E.
 
+    "bbox": [westlon, minlat, eastlon, 90.0]
 
-    "bbox": [%westlon%, %minlat%, %eastlon%, 90.0]
+Similarly, a bounding box that just touches the South Pole and forms
+a slice of an approximate spherical cap when viewed on a globe has the
+following representation in GeoJSON.
 
-A bounding box that just touches the South Pole and forms a slice of an
-approximate spherical cap when viewed on a globe has as its southwest
-corner coordinates the westernmost longitude value and 90 degrees S.
-
-
-    "bbox": [%westlon%, -90.0, %eastlon%, %maxlat%]
+    "bbox": [westlon, -90.0, eastlon, maxlat]
 
 Implementers MUST NOT use latitude values greater than 90 or less than
 -90 to imply an extent that is not a spherical cap.
@@ -611,9 +611,9 @@ new format that MUST NOT be identified as GeoJSON.
 'geo' URIs [RFC5870] identify geographic locations and precise (not uncertain)
 locations can be mapped to GeoJSON geometry objects.
 
-For this section, as in [RFC5870], "%lat%", "%lon%", "%alt%", and "%unc%"
-are placeholders for 'geo' URI latitude, longitude, altitude, and uncertainty
-values, respectively.
+For this section, as in [RFC5870], "lat", "lon", "alt", and "unc" are
+placeholders for 'geo' URI latitude, longitude, altitude, and
+uncertainty values, respectively.
 
 A 'geo' URI with two coordinates and an uncertainty ('u') parameter that
 is absent or zero, and a GeoJSON Point geometry may be mapped to each other.
@@ -622,22 +622,22 @@ parameter.
 
 'geo' URI:
 
-  geo:%lat%,%lon%
+  geo:lat,lon
 
 GeoJSON:
 
-  {"type": "Point", "coordinates": [%lon%, %lat%]}
+  {"type": "Point", "coordinates": [lon, lat]}
 
 The mapping between 'geo' URIs and GeoJSON points that specify elevation is
 shown below.
 
 'geo' URI:
 
-  geo:%lat%,%lon%,%alt%
+  geo:lat,lon,alt
 
 GeoJSON:
 
-  {"type": "Point", "coordinates": [%lon%, %lat%, %alt%]}
+  {"type": "Point", "coordinates": [lon, lat, alt]}
 
 GeoJSON has no concept of uncertainty; imprecise or uncertain 'geo' URIs thus
 cannot be mapped to GeoJSON geometries.


### PR DESCRIPTION
Variables are double quoted like "west" in text and not decorated in code examples.

A small amount of explanatory text has been added. No changes have been made to any definitions.

Resolves #213