### PR TITLE
Fix "applications using" section of media type

### DIFF
--- a/template.xml
+++ b/template.xml
@@ -122,7 +122,7 @@
          <t hangText="Security considerations:">See <xref target="security-considerations" pageno="false" format="default"/> above</t>
          <t hangText="Interoperability considerations:">See <xref target="interoperability-considerations" pageno="false" format="default"/> above</t>
          <t hangText="Published specification:">[[This document]]</t>
-         <t hangText="Applications that use this media type:">various</t>
+         <t hangText="Applications that use this media type:">No known applications currently use this media type. This media type is intended for GeoJSON applications currently using the "application/vnd.geo+json" or "application/json" media types, of which there are several categories: Web mapping (D3, Leaflet, OpenLayers), geospatial databases (PostGIS), geographic data processing APIs (C/C++, C#, Go, Haskell, Java, Javascript, Python, Rust), data analysis and storage services (Esri, Google, many others), and data dissemination (GitHub, others).</t>
          <t hangText="Additional information:">
             <list style="hanging">
               <t hangText="Magic number(s):">n/a</t>

--- a/template.xml
+++ b/template.xml
@@ -122,7 +122,7 @@
          <t hangText="Security considerations:">See <xref target="security-considerations" pageno="false" format="default"/> above</t>
          <t hangText="Interoperability considerations:">See <xref target="interoperability-considerations" pageno="false" format="default"/> above</t>
          <t hangText="Published specification:">[[This document]]</t>
-         <t hangText="Applications that use this media type:">No known applications currently use this media type. This media type is intended for GeoJSON applications currently using the "application/vnd.geo+json" or "application/json" media types, of which there are several categories: Web mapping (D3, Leaflet, OpenLayers), geospatial databases (PostGIS), geographic data processing APIs (C/C++, C#, Go, Haskell, Java, Javascript, Python, Rust), data analysis and storage services (Esri, Google, many others), and data dissemination (GitHub, others).</t>
+         <t hangText="Applications that use this media type:">No known applications currently use this media type. This media type is intended for GeoJSON applications currently using the "application/vnd.geo+json" or "application/json" media types, of which there are several categories: web mapping, geospatial databases, geographic data processing APIs, data analysis and storage services, and data dissemination.</t>
          <t hangText="Additional information:">
             <list style="hanging">
               <t hangText="Magic number(s):">n/a</t>

--- a/template.xml
+++ b/template.xml
@@ -140,6 +140,9 @@
           </t>
           <t hangText="Intended usage:">COMMON</t>
           <t hangText="Restrictions on usage:">none</t>
+          <t hangText="Restrictions on usage:">none</t>
+          <t hangText="Author:">see "Authors' Addresses" section of [[This document]].</t>
+          <t hangText="Change controller:">Internet Engineering Task Force</t>
         </list>
        </t>
    </section>


### PR DESCRIPTION
"various" isn't accurate.

The new media type has no known users. It is intended for the same categories of applications using the obsolete media type or using GeoJSON with "application/json".

I've named a few names but deliberately avoided mentioning services provided by companies affiliated with authors (Mapbox, for example).

Resolves #214 
