### PR TITLE
Remove "any number of"

### DIFF
--- a/middle.mkd
+++ b/middle.mkd
@@ -156,8 +156,7 @@ features.
 * A GeoJSON object MAY have a "bbox" member, the value of which MUST be
   a bounding box array (see [](#bounding-box)).
 
-* A GeoJSON object MAY have any number of other members (see
-  [](#extending-geojson)).
+* A GeoJSON object MAY have other members (see [](#extending-geojson)).
 
 ## Geometry Object
 


### PR DESCRIPTION
GeoJSON objects have the same security and interop considerations as other JSON objects. Nothing about GeoJSON lets its objects have "any number" of members, we're under the same laws of physics.

Resolves #216